### PR TITLE
Add hashId to subscription table

### DIFF
--- a/prisma/migrations/20231024120638_account_hash/migration.sql
+++ b/prisma/migrations/20231024120638_account_hash/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "Subscription" ADD COLUMN     "hash_id" TEXT;
+
+-- Backfill hashed account id
+UPDATE "Subscription" SET "hash_id" = encode(sha512(account::bytea), 'hex') WHERE "hash_id" IS NULL;
+
+ALTER TABLE "Subscription" ALTER COLUMN "hash_id" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,7 @@ generator client {
 model Subscription {
   id                         Int       @id @default(autoincrement())
   account                    String
+  hashId                     String    @map("hash_id")
   endpoint                   String    @unique
   gateway                    String
   pushSubscriptionObject     Json      @unique @map("push_subscription_object")

--- a/src/subscriptions/subscriptions.service.ts
+++ b/src/subscriptions/subscriptions.service.ts
@@ -2,6 +2,7 @@ import { Subscription } from '../../generated/prisma';
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 import { VError } from 'verror';
+import { createAccountHash } from './utils';
 
 @Injectable()
 export class SubscriptionsService {
@@ -29,12 +30,14 @@ export class SubscriptionsService {
       );
     }
     try {
+      const hashId = createAccountHash(account);
       await this.prisma.subscription.create({
         data: {
           account,
           pushSubscriptionObject,
           endpoint,
-          gateway
+          gateway,
+          hashId
         },
         select: {
           id: true,

--- a/src/subscriptions/utils.ts
+++ b/src/subscriptions/utils.ts
@@ -1,0 +1,7 @@
+import { createHash } from "crypto";
+
+export const createAccountHash = (account: string): string => {
+    const hash = createHash('sha512');
+    hash.update(account);
+    return hash.digest('hex');
+}


### PR DESCRIPTION
This PR alters the subscription table by adding a hash_id column that contains the hashed account id value. The migration script includes backfilling for historical data.